### PR TITLE
Fix vehicles with disappearing drivers

### DIFF
--- a/SceneManager/CollectedVehicles/CollectedVehicle.cs
+++ b/SceneManager/CollectedVehicles/CollectedVehicle.cs
@@ -1,0 +1,38 @@
+﻿using Rage;
+using System.Collections.Generic;
+using System.Linq;
+using SceneManager.Utils;
+using SceneManager.Waypoints;
+using SceneManager.Paths;
+
+namespace SceneManager.CollectedPeds
+{
+    internal class CollectedVehicle : Vehicle
+    {
+        internal CollectedPed BoundPed;
+
+        internal CollectedVehicle(Vehicle baseVehicle, CollectedPed ped) : base(baseVehicle.Handle)
+        {
+            Handle = baseVehicle.Handle;
+            BoundPed = ped;
+            //GameFiber.StartNew(() => AssignWaypointTasks(), "Task Assignment Fiber");
+        }
+
+        public bool OptionalCleanUp()
+        {
+            if (!this) return true;
+            if (!BoundPed
+                || (BoundPed && (BoundPed.IsDead || !BoundPed.CurrentVehicle || (BoundPed.CurrentVehicle && BoundPed.CurrentVehicle.Handle != Handle))))
+            {
+                if (this.IsOnFire || this.IsDead)
+                {
+                    this.Repair();
+                }
+
+                this.Delete();
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/SceneManager/EntryPoint.cs
+++ b/SceneManager/EntryPoint.cs
@@ -30,7 +30,9 @@ namespace SceneManager
             Settings.LoadSettings();
             GetAssemblyVersion();
             MenuManager.InitializeMenus();
+            Game.LogTrivial("[DEBUG] After initializing menus.");
             Hints.DisplayHintsToOpenMenu();
+            Game.LogTrivial("[DEBUG] After displaying hints to open the menu.");
 
             GameFiber.StartNew(() => UserInput.HandleKeyPress(), "Handle User Input");
 

--- a/SceneManager/SceneManager.csproj
+++ b/SceneManager/SceneManager.csproj
@@ -63,6 +63,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="API\Functions.cs" />
+    <Compile Include="CollectedVehicles\CollectedVehicle.cs" />
     <Compile Include="Menus\DriverMenu.cs" />
     <Compile Include="Menus\ExportPathMenu.cs" />
     <Compile Include="Menus\ImportPathMenu.cs" />


### PR DESCRIPTION
There have been a lot of reports about peds disappearing, leaving the vehicles empty without any peds inside.
Game crashes have also been reported. However, from my experience trying to debug the plugin, the underlying issue is again the disappearing peds.

I haven't found out the root cause of the disappearing peds - although I speculate something is wrong when the peds are being dismissed / deleted.
My fix is that vehicles get collected along with their peds. And on every clean-up cycle, vehicles without their original peds get removed.
However, this brings an issue where the peds' vehicles get deleted once they leave their cars (on their own), but I think of that as a compromise and clean behavior.